### PR TITLE
Fix typo in README (wrong library name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ if (parser.err) |err| {
 zig fetch --save git+https://github.com/matthewtolman/zig_csv#main
 ```
 
-2. In your `build.zig`, add the `httpz` module as a dependency to your program:
+2. In your `build.zig`, add the `zcsv` module as a dependency to your program:
 ```zig
 const zcsv = b.dependency("zcsv", .{
     .target = target,


### PR DESCRIPTION
I corrected the modulename from 'httpz' to 'zcsv' in the README file on Line 93