### PR TITLE
Refactor stream.zig

### DIFF
--- a/examples/03_basic_field_stream.zig
+++ b/examples/03_basic_field_stream.zig
@@ -15,7 +15,7 @@ pub fn main() !void {
     var buff = std.io.fixedBufferStream(csv);
     const reader = buff.reader();
 
-    var parser = zcsv.stream.FieldStreamPartial(
+    var parser = zcsv.stream.Parser(
         @TypeOf(reader),
         @TypeOf(stderr),
     ).init(reader, .{});

--- a/src/column.zig
+++ b/src/column.zig
@@ -247,7 +247,7 @@ pub const ParserOpts = struct {
 /// Memory is owned by returned rows, so call Row.deinit()
 pub fn Parser(comptime Reader: type) type {
     const Writer = std.ArrayList(u8).Writer;
-    const Fs = stream.FieldStreamPartial(Reader, Writer);
+    const Fs = stream.Parser(Reader, Writer);
     return struct {
         pub const Error = Fs.Error || std.mem.Allocator.Error || error{
             EndOfInput,

--- a/src/root.zig
+++ b/src/root.zig
@@ -45,7 +45,7 @@ test "imports" {
     const Writer = @TypeOf(buff.writer());
     _ = raw.init("", .{});
     _ = slice.fields.init("", .{});
-    _ = stream.FieldStreamPartial(Reader, Writer);
+    _ = stream.Parser(Reader, Writer);
     _ = stream_fast.Parser(Reader, Writer);
     _ = column.Parser(Reader);
     _ = try writer.row(buff.writer(), .{ 1, "hello", false });

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -32,7 +32,7 @@ pub fn init(comptime Reader: type, comptime Writer: type, reader: Reader, opts: 
 /// Partial writes will be made to the writer, even if there is a parse error
 /// later on
 /// This is since the streamer will parse one character at a time with no
-/// lookaheadV
+/// lookahead
 pub fn Parser(
     comptime Reader: type,
     comptime Writer: type,

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -20,7 +20,7 @@ const FSFlags = packed struct {
 /// later on
 /// This is since the streamer will parse one character at a time with no
 /// lookahead
-pub fn FieldStreamPartial(
+pub fn Parser(
     comptime Reader: type,
     comptime Writer: type,
 ) type {
@@ -225,7 +225,7 @@ test "csv field streamer partial" {
     );
     const reader = input.reader();
 
-    var stream = FieldStreamPartial(
+    var stream = Parser(
         @TypeOf(reader),
         @TypeOf(buff.writer()),
     ).init(reader, .{});


### PR DESCRIPTION
### Summary
This PR refactors the CSV parsing module to consolidate `FieldStream` and `FieldStreamPartial` into a single structure, `Parser`.  Related to #2 

### Changes
- Removed `stream.FieldStream`.
- Renamed `stream.FieldStreamPartial` to `stream.Parser`.
- Implemented a public `init` method in `stream.zig` for initializing `stream.Parser`.
- Updated two tests to use the new `init` method for initialization.
- Updated `root.zig` to reference `stream.Parser`.

### Additionally
- Updated remaining references from `FieldStreamParser` to `Parser`:
  - **Example number 03**
  - **column.zig**
  - 
  
  I have no idea if this is what you had in mind, if not, please give me some feedback.