### PR TITLE
0.5.0 release

### DIFF
--- a/.github/workflows/zigup.yml
+++ b/.github/workflows/zigup.yml
@@ -46,7 +46,7 @@ jobs:
           ./zigup run 0.14.0-dev.2164+6b2c8fc68 build test
 
       # Run with supported latest master
-      - name: Test with latest master
-        run: |
-          ./zigup fetch master
-          ./zigup run master build test
+      # - name: Test with latest master
+      #   run: |
+      #     ./zigup fetch master
+      #     ./zigup run master build test

--- a/.github/workflows/zigup.yml
+++ b/.github/workflows/zigup.yml
@@ -42,8 +42,8 @@ jobs:
       # Run with supported dev branch
       - name: Test with supported dev
         run: |
-          ./zigup fetch 0.14.0-dev.1951+857383689
-          ./zigup run 0.14.0-dev.1951+857383689 build test
+          ./zigup fetch 0.14.0-dev.2164+6b2c8fc68
+          ./zigup run 0.14.0-dev.2164+6b2c8fc68 build test
 
       # Run with supported latest master
       - name: Test with latest master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZCSV (Zig CSV)
 
-> Supported Zig versions: 0.13.0, 0.14.0-dev.1951+857383689
+> Supported Zig versions: 0.13.0, 0.14.0-dev.2164+6b2c8fc68
 
 ZCSV is a CSV parser and writer library. The goal is to provide both writers and parsers which are allocation free while also having a parser which does use memory allocations for a more developer-friendly interface.
 

--- a/build.zig
+++ b/build.zig
@@ -46,7 +46,13 @@ pub fn build(b: *std.Build) void {
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.
-    const test_step = b.step("test", "Run unit tests");
+    const test_unit_step = b.step("test-unit", "Run unit tests");
+    test_unit_step.dependOn(&run_lib_unit_tests.step);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_lib_unit_tests.step);
 
     const examples = [_]struct {

--- a/examples/03_basic_field_stream.zig
+++ b/examples/03_basic_field_stream.zig
@@ -15,10 +15,7 @@ pub fn main() !void {
     var buff = std.io.fixedBufferStream(csv);
     const reader = buff.reader();
 
-    var parser = zcsv.stream.Parser(
-        @TypeOf(reader),
-        @TypeOf(stderr),
-    ).init(reader, .{});
+    var parser = zcsv.stream.init(reader, @TypeOf(stderr), .{});
     std.log.info("Enter CSV to parse", .{});
 
     try stderr.print("> ", .{});

--- a/src/decode_writer.zig
+++ b/src/decode_writer.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+
+/// Decodes CSV values and writes the decoded values to an underlying stream
+/// Operates on a stream basis to avoid internal buffering
+/// Meant for internal use
+pub fn DecodeWriter(comptime UnderlyingWriter: type) type {
+    const AppendErr = UnderlyingWriter.Error;
+    return struct {
+        pub const Writer = std.io.Writer(
+            *@This(),
+            AppendErr,
+            @This().append,
+        );
+        pub const Error = AppendErr;
+        _writer: UnderlyingWriter,
+        _start: bool = true,
+        _last_was_quote: bool = false,
+        _quoted: bool = false,
+
+        /// Marks the end of a field so it can reset internal state
+        pub fn fieldEnd(self: *DecodeWriter(UnderlyingWriter)) void {
+            // Make sure we didn't end up in an invalid state
+            if (self._quoted) {
+                // If it's a quoted string, we should end on an "odd" quote
+                // (the ending quote)
+                std.debug.assert(self._last_was_quote);
+                // we also shouldn't be at the start
+                std.debug.assert(!self._start);
+            }
+            self._start = true;
+            self._last_was_quote = false;
+            self._quoted = false;
+        }
+
+        /// Appends CSV data to a writer
+        /// Will decode as data is being appended
+        fn append(
+            self: *DecodeWriter(UnderlyingWriter),
+            data: []const u8,
+        ) AppendErr!usize {
+            if (self._start and data.len > 0 and data[0] == '"') {
+                self._quoted = true;
+            }
+
+            // If we're writing a quoted string, then we need to write it
+            // character by character
+            if (self._quoted) {
+                for (data) |datum| {
+                    defer self._start = false;
+                    if (datum == '"') {
+                        // Make sure we started with a quote
+                        std.debug.assert(self._quoted);
+                        if (self._start) {
+                            std.debug.assert(!self._last_was_quote);
+                            // Keep track that we started with a quote
+                            continue;
+                        } else if (!self._last_was_quote) {
+                            self._last_was_quote = true;
+                            continue;
+                        } else {
+                            self._last_was_quote = false;
+                        }
+                    }
+
+                    std.debug.assert(!self._last_was_quote);
+                    std.debug.assert(!self._start or datum != '"');
+                    try self._writer.writeByte(datum);
+                }
+            } else {
+                // If we aren't a quoted string, we can take a shortcut
+                // But let's also check that the shortcut is valid
+                std.debug.assert(std.mem.indexOf(u8, data, "\"") == null);
+                try self._writer.writeAll(data);
+            }
+
+            // Report that we wrote everything
+            return data.len;
+        }
+
+        pub fn writer(self: *DecodeWriter(UnderlyingWriter)) Writer {
+            return .{ .context = self };
+        }
+
+        pub fn init(underlying: UnderlyingWriter) DecodeWriter(UnderlyingWriter) {
+            return .{ ._writer = underlying };
+        }
+    };
+}
+
+/// Creates a new CSV decode writer
+pub fn init(writer: anytype) DecodeWriter(@TypeOf(writer)) {
+    return DecodeWriter(@TypeOf(writer)).init(writer);
+}
+
+test "with fixed buffer" {
+    var buff: [100]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buff);
+
+    var decoder = init(fbs.writer());
+    try decoder.writer().writeAll("\"hello \"\"world\"\"\"");
+    try std.testing.expectEqualStrings("hello \"world\"", fbs.getWritten());
+    decoder.fieldEnd();
+
+    try decoder.writer().writeAll("\"hello\"");
+    try std.testing.expectEqualStrings("hello \"world\"hello", fbs.getWritten());
+    decoder.fieldEnd();
+
+    try decoder.writer().writeAll("hi");
+    try std.testing.expectEqualStrings("hello \"world\"hellohi", fbs.getWritten());
+    decoder.fieldEnd();
+}

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -15,14 +15,8 @@ const FSFlags = packed struct {
 /// Initializes a CSV field parser with the given reader and options.
 /// The parser will read fields one at a time from the reader, writing them
 /// to an output writer. Fields are parsed based on the configured `ParserLimitOpts`.
-pub fn init(comptime Reader: type, comptime Writer: type, reader: Reader, opts: ParserLimitOpts, flags: FSFlags) Parser(Reader, Writer) {
-    return Parser(Reader, Writer){
-        ._reader = reader,
-        ._cur = null,
-        ._next = null,
-        ._opts = opts,
-        ._flags = flags,
-    };
+pub fn init(reader: anytype, comptime Writer: type, opts: ParserLimitOpts) Parser(@TypeOf(reader), Writer) {
+    return Parser(@TypeOf(reader), Writer).init(reader, opts);
 }
 
 /// A CSV field stream will write fields to an output writer one field at a time
@@ -251,10 +245,8 @@ test "csv field streamer partial" {
     const reader = input.reader();
 
     var stream = init(
-        @TypeOf(reader),
-        @TypeOf(buff.writer()),
         reader,
-        .{},
+        @TypeOf(buff.writer()),
         .{},
     );
 
@@ -374,10 +366,8 @@ test "crlf,\" at 63" {
 
     const reader = input.reader();
     var stream = init(
-        @TypeOf(reader),
-        @TypeOf(buff.writer()),
         reader,
-        .{},
+        @TypeOf(buff.writer()),
         .{},
     );
 
@@ -404,10 +394,8 @@ test "End with quote" {
 
     const reader = input.reader();
     var stream = init(
-        @TypeOf(reader),
-        @TypeOf(buff.writer()),
         reader,
-        .{},
+        @TypeOf(buff.writer()),
         .{},
     );
 


### PR DESCRIPTION
- Made `stream` init function match signature of `stream_fast` init function
- Switched underlying parser of allocating parsers to `stream_fast` instead of `stream`