### PR TITLE
Fixed stream_fast newline bug, updated docs

### DIFF
--- a/src/decode_writer.zig
+++ b/src/decode_writer.zig
@@ -108,4 +108,19 @@ test "with fixed buffer" {
     try decoder.writer().writeAll("hi");
     try std.testing.expectEqualStrings("hello \"world\"hellohi", fbs.getWritten());
     decoder.fieldEnd();
+
+    fbs.reset();
+    try decoder.writer().writeAll("\"\"");
+    try std.testing.expectEqualStrings("", fbs.getWritten());
+    decoder.fieldEnd();
+
+    try decoder.writer().writeAll("");
+    try std.testing.expectEqualStrings("", fbs.getWritten());
+    decoder.fieldEnd();
+
+    fbs.reset();
+    try decoder.writer().writeAll("012345678901234567890123456789");
+    try decoder.writer().writeAll("012345678901234567890123456789");
+    try std.testing.expectEqualStrings("012345678901234567890123456789012345678901234567890123456789", fbs.getWritten());
+    decoder.fieldEnd();
 }

--- a/src/map_ck.zig
+++ b/src/map_ck.zig
@@ -182,4 +182,59 @@ test "csv parse into map ck" {
 
         try std.testing.expectEqualDeep(expected[ei], user);
     }
+    try std.testing.expectEqual(expected.len, ei);
+}
+
+test "csv parse into map ck larger" {
+    const User = struct {
+        id: i64,
+        name: ?[]const u8,
+        age: ?u32,
+        active: bool,
+    };
+
+    const growth = 125;
+
+    const buffer =
+        \\userid,name,age,active
+        \\1,"John ""Johnny"" Doe",32,yes
+        \\2,"Smith, Jack",53,no
+        \\3,Peter,18,yes
+        \\4,,,no
+    ++ ("\r\n5,\"\"\"Jack\"\"\",99,no" ** growth);
+
+    var input = std.io.fixedBufferStream(buffer);
+    var parser = try init(std.testing.allocator, input.reader(), .{});
+    defer parser.deinit();
+
+    const expected = [_]User{
+        User{
+            .id = 1,
+            .name = "John \"Johnny\" Doe",
+            .age = 32,
+            .active = true,
+        },
+        User{ .id = 2, .name = "Smith, Jack", .age = 53, .active = false },
+        User{ .id = 3, .name = "Peter", .age = 18, .active = true },
+        User{ .id = 4, .name = null, .age = null, .active = false },
+    } ++ ([_]User{User{ .id = 5, .name = "\"Jack\"", .age = 99, .active = false }} ** growth);
+
+    var ei: usize = 0;
+    while (parser.next()) |row| {
+        defer {
+            row.deinit();
+            ei += 1;
+        }
+
+        const user = User{
+            .id = try (row.data().get("userid").?.asInt(i64, 10)) orelse 0,
+            .name = row.data().get("name").?.asSlice(),
+            .age = try (row.data().get("age").?.asInt(u32, 10)),
+            .active = try (row.data().get("active").?.asBool()) orelse false,
+        };
+
+        try std.testing.expectEqualDeep(expected[ei], user);
+    }
+
+    try std.testing.expectEqual(expected.len, ei);
 }

--- a/src/slice/fields.zig
+++ b/src/slice/fields.zig
@@ -206,6 +206,8 @@ pub const Parser = struct {
             defer self._state.prev_quote_ends = quote_ends;
 
             const at_end = self.startPos() + chunk_size >= self._text.len;
+
+            // TODO: ADAPT
             if (at_end) {
                 const last_bit_quoted = (quoted >> @truncate(chunk_size - 1)) & 1;
                 const last_quote_end = (quote_ends >> @truncate(chunk_size - 1)) & 1;
@@ -556,9 +558,13 @@ test "crlf, at 63" {
     const fieldCount = 17;
 
     var parser = Parser.init(input, .{});
+    var b: [100]u8 = undefined;
+    var buff = std.io.fixedBufferStream(&b);
     var cnt: usize = 0;
     while (parser.next()) |_| {
+        buff.reset();
         cnt += 1;
+        try testing.expectEqual(null, std.mem.indexOf(u8, buff.getWritten(), "\n"));
     }
 
     try testing.expectEqual(fieldCount, cnt);

--- a/src/slice/fields.zig
+++ b/src/slice/fields.zig
@@ -207,7 +207,6 @@ pub const Parser = struct {
 
             const at_end = self.startPos() + chunk_size >= self._text.len;
 
-            // TODO: ADAPT
             if (at_end) {
                 const last_bit_quoted = (quoted >> @truncate(chunk_size - 1)) & 1;
                 const last_quote_end = (quote_ends >> @truncate(chunk_size - 1)) & 1;


### PR DESCRIPTION
Fixed a stream_fast bug where it would sometimes write the `LF` of a `CRLF` token. This did take a refactor to identify and fix the problem (which was related to state management for identifying if there was a previous chunk and when to skip the character). Code should be more maintainable now.

Also, added a more tests and assertions to detect the issue (and related issues).